### PR TITLE
use scope 'provided' for Firebase dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,14 @@
   <dependencies>
     <dependency>
       <groupId>com.firebase</groupId>
-      <!-- The jvm artifact is a dependency of the android artifact as well, so
-           we can just use that to work on both platforms -->
+      <!-- Use the plain java artifact here so there are no Android specific API
+           calls -->
       <artifactId>firebase-client-jvm</artifactId>
       <version>[2.0.0,)</version>
+      <!-- Since there are two artifacts (jvm and android) we only want to make
+           sure it compiles agains the API and then let people include the
+           version they want -->
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
@mikelehen This allows people to include the Firebase version people want to use in combination with GeoFire.