### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/firebase/geofire/core/GeoHashQuery.java
+++ b/src/main/java/com/firebase/geofire/core/GeoHashQuery.java
@@ -11,6 +11,9 @@ import java.util.Set;
 public class GeoHashQuery {
 
     public static class Utils {
+
+        private Utils() {}
+
         public static double bitsLatitude(double resolution) {
             return Math.min(Math.log(Constants.EARTH_MERIDIONAL_CIRCUMFERENCE/2/resolution)/Math.log(2),
                     GeoHash.MAX_PRECISION_BITS);

--- a/src/main/java/com/firebase/geofire/util/Base32Utils.java
+++ b/src/main/java/com/firebase/geofire/util/Base32Utils.java
@@ -7,6 +7,8 @@ public class Base32Utils {
 
     private static final String BASE32_CHARS = "0123456789bcdefghjkmnpqrstuvwxyz";
 
+    private Base32Utils() {}
+
     public static char valueToBase32Char(int value) {
         if (value < 0 || value >= BASE32_CHARS.length()) {
             throw new IllegalArgumentException("Not a valid base32 value: " + value);

--- a/src/main/java/com/firebase/geofire/util/Constants.java
+++ b/src/main/java/com/firebase/geofire/util/Constants.java
@@ -25,4 +25,6 @@ public class Constants {
 
     // Cutoff for floating point calculations
     public static final double EPSILON = 1e-12;
+
+    private Constants() {}
 }

--- a/src/main/java/com/firebase/geofire/util/GeoUtils.java
+++ b/src/main/java/com/firebase/geofire/util/GeoUtils.java
@@ -4,6 +4,8 @@ import com.firebase.geofire.GeoLocation;
 
 public class GeoUtils {
 
+    private GeoUtils() {}
+
     public static double distance(GeoLocation location1, GeoLocation location2) {
         return distance(location1.latitude, location1.longitude, location2.latitude, location2.longitude);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava