### PR TITLE
Update GeoFire.java

### DIFF
--- a/src/main/java/com/firebase/geofire/GeoFire.java
+++ b/src/main/java/com/firebase/geofire/GeoFire.java
@@ -31,6 +31,7 @@ package com.firebase.geofire;
 import com.firebase.geofire.core.GeoHash;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
 import com.google.firebase.database.GenericTypeIndicator;
@@ -76,8 +77,9 @@ public class GeoFire {
                 if (location != null) {
                     this.callback.onLocationResult(dataSnapshot.getKey(), location);
                 } else {
-                    String message = "GeoFire data has invalid format: " + dataSnapshot.getValue();
-                    this.callback.onCancelled(DatabaseError.fromStatus(message));
+                    String message = "GeoFire data has invalid format: " + dataSnapshot.getValue()
+                    DatabaseException exception = new DatabaseException(message);
+                    this.callback.onCancelled(DatabaseError.fromException(exception));
                 }
             }
         }


### PR DESCRIPTION
Replace call to missing DatabaseReference.fromStatus() method (in Firebase 3.0) with the use of DatabaseException

Replace code in method GeoFire.onDataChange(xx) with the lines below (and add an import of 
import com.google.firebase.database.DatabaseException;)

                    DatabaseException exception = new DatabaseException(message);
                    this.callback.onCancelled(DatabaseError.fromException(exception));