### PR TITLE
Separate Java and Android builds

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Inherit from ../pom.xml -->
+  <parent>
+    <groupId>com.firebase</groupId>
+    <artifactId>geofire</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>geofire-android</artifactId>
+  <packaging>aar</packaging>
+
+  <name>geofire-android</name>
+  <description>GeoFire is an open-source library for Android/Java that allows you to store and query a set of keys based on their geographic location.</description>
+  <organization>
+    <name>Firebase</name>
+    <url>https://www.firebase.com/</url>
+  </organization>
+  <url>https://github.com/firebase/geofire-java</url>
+  <scm>
+    <connection>scm:git:git@github.com:firebase/geofire-java.git</connection>
+    <developerConnection>scm:git:git@github.com:firebase/geofire-java.git</developerConnection>
+    <url>https://github.com/firebase/geofire-java</url>
+  </scm>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>http://firebase.mit-license.org</url>
+    </license>
+  </licenses>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <sourceDirectory>../src/main/java</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>com.simpligility.maven.plugins</groupId>
+        <artifactId>android-maven-plugin</artifactId>
+        <version>4.3.0</version> <!-- use latest release -->
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+  <repositories>
+    <repository>
+       <id>google-extras</id>
+       <url>file://${env.ANDROID_HOME}/extras/google/m2repository</url>
+    </repository>
+    <repository>
+       <id>android-extras</id>
+       <url>file://${env.ANDROID_HOME}/extras/android/m2repository</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.firebase</groupId>
+      <artifactId>firebase-database</artifactId>
+      <version>[9.0.2,)</version>
+      <scope>provided</scope>
+      <type>aar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <version>2.2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.firebase.geofire">
+  <uses-sdk
+    android:minSdkVersion="9"
+    android:targetSdkVersion="24" />
+
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Inherit from ../pom.xml -->
+  <parent>
+    <groupId>com.firebase</groupId>
+    <artifactId>geofire</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>geofire-java</artifactId>
+  <packaging>jar</packaging>
+
+  <name>geofire-java</name>
+  <description>GeoFire is an open-source library for Android/Java that allows you to store and query a set of keys based on their geographic location.</description>
+  <organization>
+    <name>Firebase</name>
+    <url>https://www.firebase.com/</url>
+  </organization>
+  <url>https://github.com/firebase/geofire-java</url>
+  <scm>
+    <connection>scm:git:git@github.com:firebase/geofire-java.git</connection>
+    <developerConnection>scm:git:git@github.com:firebase/geofire-java.git</developerConnection>
+    <url>https://github.com/firebase/geofire-java</url>
+  </scm>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>http://firebase.mit-license.org</url>
+    </license>
+  </licenses>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <!-- Plugins inherited -->
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.firebase</groupId>
+      <artifactId>firebase-server-sdk</artifactId>
+      <version>[3.0.0,)</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <version>2.2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.firebase</groupId>
   <artifactId>geofire</artifactId>
   <version>2.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
+
   <name>geofire</name>
   <description>GeoFire is an open-source library for Android/Java that allows you to store and query a set of keys based on their geographic location.</description>
   <organization>
@@ -31,6 +33,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <modules>
+      <module>android</module>
+      <module>java</module>
+  </modules>
+
   <build>
     <plugins>
       <plugin>
@@ -77,23 +85,6 @@
     </plugins>
   </build>
   <dependencies>
-    <dependency>
-      <groupId>com.google.firebase</groupId>
-      <artifactId>firebase-server-sdk</artifactId>
-      <version>[3.0.0,)</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <version>2.2.1</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.1</version>
-      <scope>test</scope>
-    </dependency>
+    <!-- Dependencies defined in child POMs -->
   </dependencies>
 </project>

--- a/src/main/java/com/firebase/geofire/GeoFire.java
+++ b/src/main/java/com/firebase/geofire/GeoFire.java
@@ -35,6 +35,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
 import com.google.firebase.database.GenericTypeIndicator;
 
+import java.lang.Throwable;
 import java.util.*;
 
 /**
@@ -77,7 +78,7 @@ public class GeoFire {
                     this.callback.onLocationResult(dataSnapshot.getKey(), location);
                 } else {
                     String message = "GeoFire data has invalid format: " + dataSnapshot.getValue();
-                    this.callback.onCancelled(DatabaseError.fromStatus(message));
+                    this.callback.onCancelled(DatabaseError.fromException(new Throwable(message)));
                 }
             }
         }


### PR DESCRIPTION
Fixes issues #28 and #25, removes blocker from PR #24 

This makes the root `pom.xml` just call out to `android/pom.xml` and `java/pom.xml` which produce an Android AAR and a Java JAR respectively.

The resulting libraries are:
  * `com.firebase:geofire` - just a POM that depends on the other two (useless, not sure how to stop it from publishing).
  * `com.firebase:geofire-java` - library for Java server users.
  * `com.firebase:geofire-android` - library for Android users.

@abehaskins or @jdimond please review