### PR TITLE
Clear change log after 2.1.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,1 @@
-v2.1.0
-  * Add method to update GeoQuery center and radius together.
 
-important - Add a new `.indexOn` rule to your Security and Firebase Rules for best performance. See the GitHub documentation for more information.
-feature - Upgraded Firebase dependency to 2.0.x.


### PR DESCRIPTION
This change log is just meant to be a per-release change log. Historical change log can be found [here](https://github.com/firebase/geofire-java/releases). Most of our open source repos use this special `changelog.txt` which has a special format which will automatically update the GitHub release notes.