### PR TITLE
App Engine Compatibility

### DIFF
--- a/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
+++ b/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
@@ -4,6 +4,8 @@ import com.google.appengine.api.ThreadManager;
 import java.util.concurrent.Executors;
 
 class AppEngineEventRaiser implements EventRaiser {
+    
+    private final ExecutorService executorService;
 
     public AppEngineEventRaiser() {
         this.executorService = Executors.newSingleThreadExecutor(ThreadManager.backgroundThreadFactory());

--- a/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
+++ b/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
@@ -1,0 +1,12 @@
+package com.firebase.geofire;
+
+import com.google.appengine.api.ThreadManager;
+import java.util.concurrent.Executors;
+
+class AppEngineEventRaiser extends ThreadEventRaiser {
+
+    @Override
+    public AppEngineEventRaiser() {
+        this.executorService = Executors.newSingleThreadExecutor(ThreadManager.backgroundThreadFactory());
+    }
+}

--- a/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
+++ b/src/main/java/com/firebase/geofire/AppEngineEventRaiser.java
@@ -3,10 +3,14 @@ package com.firebase.geofire;
 import com.google.appengine.api.ThreadManager;
 import java.util.concurrent.Executors;
 
-class AppEngineEventRaiser extends ThreadEventRaiser {
+class AppEngineEventRaiser implements EventRaiser {
 
-    @Override
     public AppEngineEventRaiser() {
         this.executorService = Executors.newSingleThreadExecutor(ThreadManager.backgroundThreadFactory());
     }
+
+    public void raiseEvent(Runnable r) {
+        this.executorService.submit(r);
+    }
 }
+

--- a/src/main/java/com/firebase/geofire/GeoFire.java
+++ b/src/main/java/com/firebase/geofire/GeoFire.java
@@ -122,12 +122,9 @@ public class GeoFire {
         this.databaseReference = databaseReference;
         EventRaiser eventRaiser;
         try {
-            eventRaiser = new AndroidEventRaiser();
-        } catch (Throwable e) {
-            // We're not on Android, try using GAE-specific event raiser
             eventRaiser = new AppEngineEventRaiser();
         } catch (Throwable e) {
-            // We're not on Android or GAE, use the ThreadEventRaiser
+            // We're not on GAE, use the ThreadEventRaiser
             eventRaiser = new ThreadEventRaiser();
         }
         this.eventRaiser = eventRaiser;

--- a/src/main/java/com/firebase/geofire/GeoFire.java
+++ b/src/main/java/com/firebase/geofire/GeoFire.java
@@ -124,7 +124,10 @@ public class GeoFire {
         try {
             eventRaiser = new AndroidEventRaiser();
         } catch (Throwable e) {
-            // We're not on Android, use the ThreadEventRaiser
+            // We're not on Android, try using GAE-specific event raiser
+            eventRaiser = new AppEngineEventRaiser();
+        } catch (Throwable e) {
+            // We're not on Android or GAE, use the ThreadEventRaiser
             eventRaiser = new ThreadEventRaiser();
         }
         this.eventRaiser = eventRaiser;

--- a/src/main/java/com/firebase/geofire/ThreadEventRaiser.java
+++ b/src/main/java/com/firebase/geofire/ThreadEventRaiser.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors;
 
 class ThreadEventRaiser implements EventRaiser {
 
-    protected final ExecutorService executorService;
+    private final ExecutorService executorService;
 
     public ThreadEventRaiser() {
         this.executorService = Executors.newSingleThreadExecutor();

--- a/src/main/java/com/firebase/geofire/ThreadEventRaiser.java
+++ b/src/main/java/com/firebase/geofire/ThreadEventRaiser.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Executors;
 
 class ThreadEventRaiser implements EventRaiser {
 
-    private final ExecutorService executorService;
+    protected final ExecutorService executorService;
 
     public ThreadEventRaiser() {
         this.executorService = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
Google App Engine requires threads be made via the ThreadManager API.  Because geofire-java does not currently use it, geofire-java is incompatible with GAE.  This PR adds a new type of EventRaiser that uses the ThreadManager background ThreadFactory to create threads.

Because I have not yet figured out how to import a fork of a Maven module into a GAE service module, I have not been able to test this change. I invite any feedback you have, or even better, instructions on how to test this for myself.