### PR TITLE
Fail early when getting a Datasnapshot without a location.

### DIFF
--- a/src/main/java/com/firebase/geofire/GeoQuery.java
+++ b/src/main/java/com/firebase/geofire/GeoQuery.java
@@ -263,7 +263,7 @@ public class GeoQuery {
         if (location != null) {
             this.updateLocationInfo(dataSnapshot.getKey(), location);
         } else {
-            // throw an error in future?
+            throw new AssertionError("Got Datasnapshot without location with key " + dataSnapshot.getKey());
         }
     }
 
@@ -272,7 +272,7 @@ public class GeoQuery {
         if (location != null) {
             this.updateLocationInfo(dataSnapshot.getKey(), location);
         } else {
-            // throw an error in future?
+            throw new AssertionError("Got Datasnapshot without location with key " + dataSnapshot.getKey());
         }
     }
 


### PR DESCRIPTION
Let's fail early instead of not doing anything and if we ever run into this case we can debug this and fix the root cause for this.