### PR TITLE
Refactor redundant expectEvents method.

### DIFF
--- a/src/test/java/com/firebase/geofire/TestListener.java
+++ b/src/test/java/com/firebase/geofire/TestListener.java
@@ -1,14 +1,13 @@
 package com.firebase.geofire;
 
-import junit.framework.Assert;
-
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import junit.framework.Assert;
 
 public class TestListener {
     private final List<String> events = new ArrayList<>();
@@ -17,38 +16,23 @@ public class TestListener {
 
     protected void addEvent(String event) {
         lock.lock();
+
         try {
-            this.events.add(event);
+            events.add(event);
             condition.signal();
         } finally {
             lock.unlock();
         }
     }
 
-    public void expectEvents(Set<String> events) throws InterruptedException {
+    public void expectEvents(Collection<String> events) throws InterruptedException {
         boolean stillWaiting = true;
         lock.lock();
-        try {
-            while (!new HashSet(this.events).equals(events)) {
-                if (!stillWaiting) {
-                    Assert.assertEquals(events, new HashSet(this.events));
-                    Assert.fail("Timeout occured");
-                    return;
-                }
-                stillWaiting = condition.await(10, TimeUnit.SECONDS);
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
 
-    public void expectEvents(List<String> events) throws InterruptedException {
-        boolean stillWaiting = true;
-        lock.lock();
         try {
-            while (!this.events.equals(events)) {
+            while (!new LinkedHashSet<>(this.events).equals(events)) {
                 if (!stillWaiting) {
-                    Assert.assertEquals(events, this.events);
+                    Assert.assertEquals(events, new LinkedHashSet<>(this.events));
                     Assert.fail("Timeout occured");
                     return;
                 }


### PR DESCRIPTION
The new test fails locally `dataChanged` but this is expected right? Since there's the precision bug.

Part of #101 