### PR TITLE
Fixes #134 and #28

### DIFF
--- a/common/src/main/java/com/firebase/geofire/GeoFire.java
+++ b/common/src/main/java/com/firebase/geofire/GeoFire.java
@@ -28,17 +28,20 @@
 
 package com.firebase.geofire;
 
+import static com.firebase.geofire.util.GeoUtils.capRadius;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import com.firebase.geofire.core.GeoHash;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.ValueEventListener;
 import com.google.firebase.database.GenericTypeIndicator;
-import java.lang.Throwable;
-import java.util.*;
-import java.util.logging.Logger;
-
-import static com.firebase.geofire.util.GeoUtils.capRadius;
+import com.google.firebase.database.ValueEventListener;
 
 /**
  * A GeoFire instance is used to store geo location data in Firebase.
@@ -172,14 +175,14 @@ public class GeoFire {
         updates.put("g", geoHash.getGeoHashString());
         updates.put("l", Arrays.asList(location.latitude, location.longitude));
         if (completionListener != null) {
-            keyRef.setValue(updates, geoHash.getGeoHashString(), new DatabaseReference.CompletionListener() {
+            keyRef.updateChildren(updates, new DatabaseReference.CompletionListener() {
                 @Override
                 public void onComplete(DatabaseError databaseError, DatabaseReference databaseReference) {
                     completionListener.onComplete(key, databaseError);
                 }
             });
         } else {
-            keyRef.setValue(updates, geoHash.getGeoHashString());
+            keyRef.updateChildrenAsync(updates);
         }
     }
 
@@ -212,7 +215,7 @@ public class GeoFire {
                 }
             });
         } else {
-            keyRef.setValue(null);
+            keyRef.setValueAsync(null);
         }
     }
 


### PR DESCRIPTION
Using keyRef.updateChildren instead of keyRef.setValue also fixes a huge amount of unnecessary 'onDataExited(DataSnapshot dataSnapshot)' events, which has not been reported yet. keyRef.updateChildren understands if the data needs to be inserted or updated. No need to use setValue here. Since priorities are not relevant anymore (https://stackoverflow.com/questions/31577915/what-does-priority-mean-in-firebase) i decided to not consider them anymore.